### PR TITLE
Fix quitting Maestral when setup dialog is closed

### DIFF
--- a/src/maestral_cocoa/app.py
+++ b/src/maestral_cocoa/app.py
@@ -186,7 +186,7 @@ class MaestralGui(SystemTrayApp):
             create_task(self.periodic_refresh_gui())
             create_task(self.periodic_check_for_updates())
 
-    def _on_setup_completed(self):
+    def _on_setup_completed(self, sender):
 
         if self.setup_dialog.exit_status == self.setup_dialog.ACCEPTED:
             self.mdbx.start_sync()

--- a/src/maestral_cocoa/private/implementation/cocoa/factory.py
+++ b/src/maestral_cocoa/private/implementation/cocoa/factory.py
@@ -761,7 +761,7 @@ class WindowDeletage(NSObject):
     @objc_method
     def windowWillClose_(self, notification) -> None:
         if self.interface.on_close:
-            self.interface.on_close()
+            self.interface.on_close(self.interface)
 
         if not self.interface.is_dialog:
 


### PR DESCRIPTION
See https://github.com/SamSchott/maestral/issues/403. This PR fixes an issue where Maestral does not quit when the setup dialog is closed. This is due to change in API in toga 0.3.0.dev28.

Wait until 0.3.0.dev28 is released before merging.