### PR TITLE
Fix Python 3.6 compatibility issues

### DIFF
--- a/src/maestral_cocoa/constants.py
+++ b/src/maestral_cocoa/constants.py
@@ -4,7 +4,7 @@
 import sys
 
 try:
-    from importlib.metadata import metadata
+    from importlib.metadata import metadata  # type: ignore
 except ImportError:
     # Backwards compatibility Python 3.7 and lower
     from importlib_metadata import metadata  # type: ignore

--- a/src/maestral_cocoa/resources/__init__.py
+++ b/src/maestral_cocoa/resources/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 try:
-    from importlib.resources import path
+    from importlib.resources import path  # type: ignore
 except ImportError:
     from importlib_resources import path  # type: ignore
 

--- a/src/maestral_cocoa/utils.py
+++ b/src/maestral_cocoa/utils.py
@@ -98,7 +98,7 @@ def generate_async_maestral(config_name: str, func_name: str, *args) -> AsyncGen
 def request_authorization_from_user_and_run(exe: List[str]) -> None:
     # shlex.join requires Python 3.8 and later.
 
-    cmd = shlex.join(exe)
+    cmd = shlex.join(exe)  # type: ignore
 
     source = f'do shell script "{cmd}" with administrator privileges'
 


### PR DESCRIPTION
* Fixes type annotations which are only compatible with Python 3.9 and later (see https://github.com/SamSchott/maestral/issues/492).
* Add mypy ignore annotations for backward-compatible imports.
* Run linting on Python 3.6 to catch future regressions. 