### PR TITLE
Dock icon improvements

### DIFF
--- a/macOS/Xcode/Maestral/Maestral/Info.plist
+++ b/macOS/Xcode/Maestral/Maestral/Info.plist
@@ -41,6 +41,8 @@
 	<false/>
 	<key>SUFeedURL</key>
 	<string>https://maestral.app/appcast.xml</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>SUPublicEDKey</key>
 	<string>RugM2eM14xHixaeHpl5uWSq7+sDZvYi52Xpz4IXpAdA=</string>
 </dict>

--- a/src/maestral_cocoa/app.py
+++ b/src/maestral_cocoa/app.py
@@ -129,6 +129,7 @@ class MaestralGui(SystemTrayApp):
         pending_folder = self.mdbx.pending_dropbox_folder
 
         if pending_link or pending_folder:
+            self.show_dock_icon()
             self.setup_dialog = SetupDialog(mdbx=self.mdbx, app=self)
             self.setup_dialog.raise_()
             self.setup_dialog.on_success = self.on_setup_completed


### PR DESCRIPTION
This PR tweaks when the dock icon is shown by setting the plist entry `LSUIElement` to `True` and overriding toga's `toga_cocoa.App.create()` method to not set the activation policy to `NSApplicationActivationPolicyRegular`. This has a few practical effects:

1. The dock icon no longer automatically appears during app launch. This provides a better user experience, especially when starting Maestral automatically on login.
2. The dock icon no longer appears when clicking on a desktop notification.

Since we still want to show a Dock icon when the setup dialog window is open, this is now done explicitly during startup.

This PR fixes https://github.com/SamSchott/maestral/issues/547.