### PR TITLE
Ref management

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     "maestral>=1.5.2",
     "markdown2",
     "toga==0.3.0.dev29",
-    "rubicon-objc>=0.4.0",
+    "rubicon-objc>=0.4.2",
 ]
 
 dev_requires = [

--- a/src/maestral_cocoa/private/implementation/cocoa/factory.py
+++ b/src/maestral_cocoa/private/implementation/cocoa/factory.py
@@ -4,6 +4,7 @@
 import sys
 import os.path as osp
 import platform
+from ctypes import py_object
 
 # external imports
 import toga
@@ -14,6 +15,7 @@ from rubicon.objc import (
     CGRectMake,
     ObjCClass,
     objc_method,
+    objc_property,
     SEL,
     at,
 )
@@ -200,8 +202,6 @@ class Label(Widget):
 
     def create(self):
         self.native = NSTextField.labelWithString("")
-        self.native.impl = self
-        self.native.interface = self.interface
 
         # Add the layout constraints
         self.add_constraints()
@@ -252,8 +252,6 @@ class RichLabel(Widget):
     def create(self):
         self._color = None
         self.native = NSTextView.alloc().init()
-        self.native.impl = self
-        self.native.interface = self.interface
 
         self.native.drawsBackground = False
         self.native.editable = False
@@ -337,6 +335,10 @@ class FreestandingIconButton(TogaButton):
 
 
 class SwitchTarget(NSObject):
+
+    interface = objc_property(py_object, weak=True)
+    impl = objc_property(py_object, weak=True)
+
     @objc_method
     def onPress_(self, obj) -> None:
         if self.interface.on_toggle:
@@ -398,6 +400,10 @@ class Switch(Widget):
 
 
 class FileChooserTarget(NSObject):
+
+    interface = objc_property(py_object, weak=True)
+    impl = objc_property(py_object, weak=True)
+
     @objc_method
     def onSelect_(self, obj) -> None:
         if self.impl.native.indexOfSelectedItem == 2:
@@ -495,6 +501,10 @@ class FileSelectionButton(Widget):
 
 
 class TogaMenuItem(NSMenuItem):
+
+    interface = objc_property(py_object, weak=True)
+    impl = objc_property(py_object, weak=True)
+
     @objc_method
     def onPress_(self, obj) -> None:
         if self.interface.action:
@@ -554,6 +564,10 @@ class MenuItemSeparator:
 
 
 class TogaMenu(NSMenu):
+
+    interface = objc_property(py_object, weak=True)
+    impl = objc_property(py_object, weak=True)
+
     @objc_method
     def menuWillOpen_(self, obj) -> None:
         self.impl._visible = True
@@ -620,6 +634,10 @@ class StatusBarItem:
 
 
 class SystemTrayAppDelegate(NSObject):
+
+    interface = objc_property(py_object, weak=True)
+    impl = objc_property(py_object, weak=True)
+
     @objc_method
     def applicationWillTerminate_(self, sender):
         if self.interface.app.on_exit:
@@ -846,6 +864,10 @@ class SystemTrayApp(TogaApp):
 
 
 class WindowDeletage(TogaWindowDeletage):
+
+    interface = objc_property(py_object, weak=True)
+    impl = objc_property(py_object, weak=True)
+
     @objc_method
     def windowWillClose_(self, notification) -> None:
 


### PR DESCRIPTION
* Bump rubicon-objc requirement to >=0.4.2.
* Declare all properties on native Objective-C classes as `weak` to avoid reference cycles in Objective-C.