### PR TITLE
Set AssociatedBundleIdentifiers in Launch Agent plist

### DIFF
--- a/macOS/Xcode/Maestral/Maestral.xcodeproj/project.pbxproj
+++ b/macOS/Xcode/Maestral/Maestral.xcodeproj/project.pbxproj
@@ -374,7 +374,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.samschott.maestral-cocoa";
+				PRODUCT_BUNDLE_IDENTIFIER = com.samschott.maestral;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
@@ -401,7 +401,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.samschott.maestral-cocoa";
+				PRODUCT_BUNDLE_IDENTIFIER = com.samschott.maestral;
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
 			name = Release;

--- a/macOS/Xcode/Maestral/Maestral/Info.plist
+++ b/macOS/Xcode/Maestral/Maestral/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIconName</key>
 	<string>Maestral</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.samschott.maestral-cocoa</string>
+	<string>com.samschott.maestral</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/src/maestral_cocoa/autostart.py
+++ b/src/maestral_cocoa/autostart.py
@@ -35,6 +35,7 @@ class AutoStart:
                 launchd_id,
                 start_cmd,
                 EnvironmentVariables=ENV,
+                AssociatedBundleIdentifiers=BUNDLE_ID,
             )
 
         elif self.implementation == SupportedImplementations.xdg_desktop:

--- a/src/maestral_cocoa/autostart.py
+++ b/src/maestral_cocoa/autostart.py
@@ -24,16 +24,15 @@ class AutoStart:
     _impl: AutoStartBase
 
     def __init__(self, config_name: str) -> None:
-
         self.implementation = self._get_available_implementation()
 
         start_cmd_list = [sys.executable, "-m", "maestral_cocoa", "-c", config_name]
         start_cmd = " ".join(start_cmd_list)
-        bundle_id = "{}.{}".format(BUNDLE_ID, config_name)
+        launchd_id = "{}.{}".format(BUNDLE_ID, config_name)
 
         if self.implementation == SupportedImplementations.launchd:
             self._impl = AutoStartLaunchd(
-                bundle_id,
+                launchd_id,
                 start_cmd,
                 EnvironmentVariables=ENV,
             )


### PR DESCRIPTION
This allows macOS Ventura to correctly pick up which app is associated with a LaunchAgent plist entry and display this information in System Settings' "Login Items" pane. See [SMAppService docs](https://developer.apple.com/documentation/servicemanagement/updating_helper_executables_from_earlier_versions_of_macos) ("Connect services to app names in System Settings") for Apple's documentation on this.

Fixes https://github.com/samschott/maestral/issues/798.