### PR TITLE
Require Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ sources = ["src/maestral_cocoa"]
 requires = [
     "chardet==5.1.0",
     "click==8.1.3",
-    "importlib_metadata;python_version<'3.8'",
     "maestral==1.8.1.dev0",
     "markdown2==2.4.8",
     "rubicon-objc==0.4.6",

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     markdown2
     toga==0.3.1
     rubicon-objc>=0.4.5
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 where = src

--- a/src/maestral_cocoa/constants.py
+++ b/src/maestral_cocoa/constants.py
@@ -3,7 +3,7 @@
 # system imports
 import sys
 
-from importlib_metadata import metadata
+from importlib.metadata import metadata
 
 
 # detect if we have been built with briefcase or frozen with PyInstaller

--- a/src/maestral_cocoa/resources/__init__.py
+++ b/src/maestral_cocoa/resources/__init__.py
@@ -1,10 +1,12 @@
 try:
+    # Python 3.9 and later
     from importlib.resources import as_file, files  # type: ignore
 
     def resource_path(name: str) -> str:
         return str(files("maestral_cocoa.resources") / name)
 
 except ImportError:
+    # Python 3.8
     from importlib.resources import path  # type: ignore
 
     def resource_path(name: str) -> str:


### PR DESCRIPTION
Also drop `importlib_metadata` dependency in favor of builtin `importlib.metadata`.