### PR TITLE
Fix code signing issues in CI

### DIFF
--- a/.bumpversion-build.cfg
+++ b/.bumpversion-build.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 106
+current_version = 107
 parse = ^
 	(?P<major>\d+)
 serialize = 

--- a/.bumpversion-build.cfg
+++ b/.bumpversion-build.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 107
+current_version = 108
 parse = ^
 	(?P<major>\d+)
 serialize = 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,15 +59,19 @@ jobs:
           briefcase build macOS Xcode --no-input
 
           # Run post-build scripts.
-          # - add CLI executable
+          # - add CLI executable and sign it
           # - keep .pyc files only to save space
           APP_PATH=$( find . -name "*Maestral.app" | head -n 1)
-          python3 scripts/post-build-macos.py $APP_PATH
+          ENTITLEMENTS_PATH=$( find . -name "*maestral-cocoa.entitlements" | head -n 1)
+          python3 scripts/post-build-macos.py $APP_PATH \
+            --identity "$DEV_ID" \
+            --entitlements $ENTITLEMENTS_PATH
 
           # Package as dmg.
           briefcase package macOS Xcode --identity "$DEV_ID" --no-input
 
           # Prepare output for upload.
+          DMG_PATH=$( find . -name "*.dmg" )
           DMG_PATH=$( find . -name "*.dmg" )
           DMG_NAME=$( basename "$DMG_PATH" )
           echo "dmg created: $DMG_PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires = [
 cleanup_paths = [
     "*/unittest",
 ]
-build = "106"
+build = "107"
 
 [tool.briefcase.app.maestral-cocoa.linux]
 supported = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires = [
 cleanup_paths = [
     "*/unittest",
 ]
-build = "107"
+build = "108"
 
 [tool.briefcase.app.maestral-cocoa.linux]
 supported = false

--- a/scripts/post-build-macos.py
+++ b/scripts/post-build-macos.py
@@ -52,7 +52,7 @@ subprocess.run(
 print("# ==== prune py files and replace with pyc ==============================")
 
 print("compiling py -> pyc")
-compileall.compile_dir(str(RESOURCE_PATH), optimize=2, ddir="", legacy=True)
+compileall.compile_dir(str(RESOURCE_PATH), optimize=2, ddir="", legacy=True, quiet=1)
 
 print("removing py files")
 for path in RESOURCE_PATH.glob("**/*.py"):

--- a/scripts/post-build-macos.py
+++ b/scripts/post-build-macos.py
@@ -1,12 +1,19 @@
-import sys
 import shutil
 import compileall
 import subprocess
+import argparse
 from pathlib import Path
 from setuptools.dist import Distribution
 from setuptools.command.egg_info import write_entries
 
-BUNDLE_PATH = Path(sys.argv[1])
+parser = argparse.ArgumentParser()
+parser.add_argument("bundlepath")
+parser.add_argument("-i", "--identity", help="code signing identity")
+parser.add_argument("-e", "--entitlements", help="code signing entitlements")
+
+args = parser.parse_args()
+
+BUNDLE_PATH = Path(args.bundlepath)
 RESOURCE_PATH = BUNDLE_PATH / "Contents" / "Resources"
 APP_PATH = BUNDLE_PATH / "Contents" / "Resources" / "app"
 APP_PACKAGES_PATH = BUNDLE_PATH / "Contents" / "Resources" / "app_packages"
@@ -22,7 +29,25 @@ write_entries(cmd, "entry_points", DIST_INFO_TARGET_PATH / "entry_points.txt")
 
 print("# ==== copy over cli executable =========================================")
 
-shutil.copy("scripts/maestral-cli", BUNDLE_PATH / "Contents" / "MacOS")
+cli_executable_path = BUNDLE_PATH / "Contents" / "MacOS" / "maestral-cli"
+shutil.copy("scripts/maestral-cli", cli_executable_path)
+
+print("# ==== sign cli executable ==============================================")
+
+subprocess.run(
+    [
+        "codesign",
+        str(cli_executable_path),
+        "--sign",
+        args.identity,
+        "--force",
+        "--entitlements",
+        args.entitlements,
+        "--options",
+        "runtime",
+    ],
+    check=True,
+)
 
 print("# ==== prune py files and replace with pyc ==============================")
 


### PR DESCRIPTION
The latest briefcase only code signs mach-o binaries, frameworks, etc, but not our CLI script. This causes code signing to fail when trying to sign the eventual app bundle.

This PR addresses this by manually signing the cli script after copying it into the bundle. 